### PR TITLE
Send stdin through a pipe when attaching

### DIFF
--- a/dockerpty.go
+++ b/dockerpty.go
@@ -82,9 +82,11 @@ func StartExec(client *docker.Client, exec *docker.Exec) (err error) {
 }
 
 func attachToContainer(client *docker.Client, containerID string, errorChan chan error) {
+	r, w := io.Pipe()
+	go io.Copy(w, os.Stdin)
 	err := client.AttachToContainer(docker.AttachToContainerOptions{
 		Container:    containerID,
-		InputStream:  os.Stdin,
+		InputStream:  r,
 		OutputStream: os.Stdout,
 		ErrorStream:  os.Stderr,
 		Stdin:        true,


### PR DESCRIPTION
When the connection to the Docker server drops (e.g. due to the
container exiting), fsouza/go-dockerclient closes the input stream we
provided to it [[1](https://github.com/fsouza/go-dockerclient/blob/1399676f53e6ccf46e0bf00751b21bed329bc60e/client.go#L621)]. io.Copy is used to copy the input stream to the
docker server [[2](https://github.com/fsouza/go-dockerclient/blob/1399676f53e6ccf46e0bf00751b21bed329bc60e/client.go#L636)], and AttachToContainer only returns once that
io.Copy stops blocking. However, closing os.Stdin doesn't have an
immediate effect on io.Copy (but you do get an error next time stdin
receives any data). This results in the call to AttachToContainer
blocking until stdin received more data.

To get around this issue, we pass fsouza/go-dockerclient the reader side
of an io.Pipe, and in a separate goroutine copy from stdin to the writer
half of the pipe. When fsouza/go-dockerclient closes the reader half of
the pipe, the io.Copy call at [[2](https://github.com/fsouza/go-dockerclient/blob/1399676f53e6ccf46e0bf00751b21bed329bc60e/client.go#L636)] immediately unblocks, letting
AttachToContainer return.

A caveat is that we'll leak the goroutine that copies from stdin to the
pipe until stdin receives more input (when it'll cause a read error that
is left unhandled).

The fundamental problem here is that we have no way of interrupting the
call to stdin.Read() (from within io.Copy) from another goroutine when
the connection is severed.
